### PR TITLE
Integrate OpenRouter descriptions

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+REACT_APP_OPENROUTER_API_KEY=your-api-key
+

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## OpenRouter Integration
+
+Set the `REACT_APP_OPENROUTER_API_KEY` environment variable in a `.env.local` file before running the app. This key is used to retrieve AI-generated character descriptions when opening the character modal.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 
 ## OpenRouter Integration
 
-Set the `REACT_APP_OPENROUTER_API_KEY` environment variable in a `.env.local` file before running the app. This key is used to retrieve AI-generated character descriptions when opening the character modal.
+Set the `REACT_APP_OPENROUTER_API_KEY` environment variable in a `.env.local` file before running the app. You can copy `.env.local.example` to `.env.local` and fill in your API key. This key is used to retrieve AI-generated character descriptions when opening the character modal.

--- a/src/components/custom-dialog/character-dialog.scss
+++ b/src/components/custom-dialog/character-dialog.scss
@@ -9,6 +9,9 @@
         margin-bottom: 0.3rem;
         border-bottom: 1px solid gray;
     }
+    &-description{
+        margin: 0.5rem 0;
+    }
     @media (max-width: 768px){
         .css-m9glnp-MuiPaper-root-MuiDialog-paper{
             width: 70%;

--- a/src/components/custom-dialog/custom-dialog.tsx
+++ b/src/components/custom-dialog/custom-dialog.tsx
@@ -15,7 +15,9 @@ export const CustomCharatersDialog = (props: DialogProps) => {
     const [open, setOpen] = useState<boolean>(false);
     const [firstEpisode, setFirstEpisode] = useState<string>('');
     const [lastEpisode, setLastEpisode] = useState<string>('');
-    const [error,setError] = useState<boolean>(false);
+    const [error, setError] = useState<boolean>(false);
+    const [description, setDescription] = useState<string>('');
+    const [descriptionLoading, setDescriptionLoading] = useState<boolean>(false);
     const theme = useTheme();
     const fullScreen = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -23,7 +25,9 @@ export const CustomCharatersDialog = (props: DialogProps) => {
     useEffect(() => {
         setError(false);
         setOpen(true);
+        setDescription('');
         getCharactersEpisodeData(props.characterDetailsDialog.firstEpisode, props.characterDetailsDialog.lastEpisode);
+        getCharacterDescription(props.characterDetailsDialog.characterName, props.characterDetailsDialog.characterId);
     }, [props.characterDetailsDialog]);
 
     const handleClose = () => {
@@ -54,16 +58,42 @@ export const CustomCharatersDialog = (props: DialogProps) => {
         })
     }
 
+    const getCharacterDescription = (name: string, id: number) => {
+        setDescriptionLoading(true);
+        axios.post('https://openrouter.ai/api/v1/chat/completions', {
+            model: 'gpt-3.5-turbo',
+            messages: [{
+                role: 'user',
+                content: `Briefly describe the Rick and Morty character ${name} in one concise paragraph.`
+            }]
+        }, {
+            headers: {
+                'Authorization': `Bearer ${process.env.REACT_APP_OPENROUTER_API_KEY}`
+            }
+        }).then(function (response) {
+            if (response.data && response.data.choices && response.data.choices.length > 0) {
+                setDescription(response.data.choices[0].message.content.trim());
+            } else {
+                setDescription('No description available.');
+            }
+        }).catch(function () {
+            setDescription('Failed to load description.');
+        }).finally(() => {
+            setDescriptionLoading(false);
+        });
+    }
+
 
 
     return <Dialog fullScreen={fullScreen} open={open} onClose={handleClose} className="character-dialog" aria-labelledby="charater-dialog-title" >
            <>{error ? <div className="error">No Data on Character</div> : <DialogContent><img src={props.characterDetailsDialog.image} alt="" className="character-dialog-image" />
             <h2>{props.characterDetailsDialog.characterName}</h2>
+            <p className="character-dialog-description">{descriptionLoading ? 'Loading description...' : description}</p>
             <div className="character-dialog-episode">
                 <span className="bold">First Episode:</span> {firstEpisode}
             </div>
             <div className="character-dialog-episode">
                 <span className="bold">Last Episode:</span> {lastEpisode}
-            </div></DialogContent>}</> 
+            </div></DialogContent>}</>
     </Dialog>
 }


### PR DESCRIPTION
## Summary
- fetch episode and character info in the modal and ask OpenRouter for a description
- render the loading text, API result, or an error message
- style the description paragraph
- document required `REACT_APP_OPENROUTER_API_KEY` env variable

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install` *(fails: network access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ad3150230832998e83814f00cd590